### PR TITLE
Refactor: Improve batch scripts and documentation

### DIFF
--- a/PHONECONTROL.BAT
+++ b/PHONECONTROL.BAT
@@ -1,6 +1,22 @@
-@echo off  
-:: Remember to check for updates on scrcpy if you encounter issues.  
-cd "C:\Users\unknown\Desktop\PHONE-CONTROL-PROJECT"  
-adb start-server  
-scrcpy --video-bit-rate 8M --max-size 1080 --render-driver opengl --stay-awake --show-touch  
-pause 
+@echo off
+:: Remember to check for updates on scrcpy if you encounter issues.
+cd /d "%~dp0"
+
+echo Starting ADB server...
+Software\adb.exe start-server
+if %ERRORLEVEL% neq 0 (
+    echo Error: Failed to start ADB server. Ensure ADB is correctly placed in the Software folder and no other ADB instance is conflicting.
+    pause
+    exit /b %ERRORLEVEL%
+)
+
+echo Starting scrcpy...
+Software\scrcpy.exe --video-bit-rate 8M --max-size 1080 --render-driver opengl --stay-awake --show-touch
+if %ERRORLEVEL% neq 0 (
+    echo Error: Failed to start scrcpy. Ensure scrcpy is correctly placed in the Software folder and your device is connected and authorized.
+    pause
+    exit /b %ERRORLEVEL%
+)
+
+echo scrcpy closed.
+pause

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ To set up the Phone Control Project, follow these steps:
 \	```bash  
 \	choco install adb scrcpy -y  
 \	```  
+**Note:** The `PHONECONTROL.BAT` script is configured to use the `adb` and `scrcpy` versions bundled within the `Software/` directory. The `setup.bat` script (which uses Chocolatey to install `adb` and `scrcpy` system-wide) is provided as an alternative for users who prefer system-wide installations or to ensure all dependencies are met if issues occur with the bundled versions.
   
 4. **Adjust Settings on Android Device:**  
 - Enable USB Debugging on your Android device in `Settings  Options`.  
@@ -30,11 +31,14 @@ To set up the Phone Control Project, follow these steps:
 - Use a USB cable to connect your device to your computer, and make sure to authorize the connection when prompted on your device.  
   
 ## Usage  
-To run the Phone Control Project, execute the following command in the command prompt:  
+To run the Phone Control Project, simply execute `PHONECONTROL.BAT` from the project's root directory:
 \	```bash  
-\	C:\Users\unknown\Desktop\PHONE-CONTROL-PROJECT\PHONECONTROL.BAT  
+\	PHONECONTROL.BAT
 \	```  
-This will start the scrcpy application with the defined settings.  
+Ensure you are in the project's root directory when running this command.
+
+### How it Works
+The `PHONECONTROL.BAT` script is specifically configured to use the `adb.exe` and `scrcpy.exe` versions located within the `Software/` subdirectory of this project. This approach ensures that the project is portable and self-contained, meaning it does not rely on system-wide installations of ADB or scrcpy and won't interfere with other versions you might have installed.
   
 ## Prerequisites  
 - Windows OS  
@@ -52,4 +56,4 @@ Always fetch the latest updates from the repository:
 If you would like to contribute, feel free to submit a Pull Request with your changes!  
   
 ## License  
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details. 
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/scrcpy_instructions.txt
+++ b/scrcpy_instructions.txt
@@ -1,14 +1,22 @@
-To control your phone from your desktop using scrcpy, follow the steps below:  
-  
-1. Download scrcpy and extract it to a folder.  
-2. Enable USB Debugging on your phone from Developer options.  
-3. Connect your phone to your computer via USB cable.  
-4. Update the PHONECONTROL.BAT file with the following content:  
-@echo off  
-"C:\Users\unknown\Desktop\MASTER PACK SOFTWARE\scrcpy-win64-v2.5"  
-adb start-server  
-scrcpy --video-bit-rate 8M --max-size 1024  
-  
-5. Double-click the PHONECONTROL.BAT file on your desktop to launch scrcpy.  
-  
-Enjoy controlling your phone from your desktop! 
+Quick steps to control your Android device using this project:
+
+1.  **Prerequisites:**
+    *   Ensure you have cloned or downloaded this project repository.
+    *   The necessary `adb` and `scrcpy` tools are included in the `Software/` directory.
+    *   (Optional) You can run `setup.bat` if you prefer to install `adb` and `scrcpy` system-wide using Chocolatey.
+
+2.  **Enable USB Debugging:**
+    *   On your Android device, go to `Settings` > `About phone`.
+    *   Tap on `Build number` repeatedly (usually 7 times) until Developer Options are enabled.
+    *   Go to `Settings` > `System` > `Developer options` (or similar).
+    *   Enable `USB debugging`.
+
+3.  **Connect Your Device:**
+    *   Connect your Android device to your computer using a USB cable.
+    *   Authorize the USB debugging connection on your device when prompted.
+
+4.  **Run the Control Script:**
+    *   Navigate to the root directory of this project in your command prompt or file explorer.
+    *   Execute the `PHONECONTROL.BAT` script.
+
+This will start screen mirroring and control. Enjoy!

--- a/setup.bat
+++ b/setup.bat
@@ -8,10 +8,33 @@ if not exist "C:\ProgramData\chocolatey" (
         [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
         iex (new-object net.webclient).downloadstring('https://chocolatey.org/install.ps1')
     }"
+    if %ERRORLEVEL% neq 0 (
+        echo Error: Chocolatey installation failed.
+        pause
+        exit /b %ERRORLEVEL%
+    )
+    echo Chocolatey installed successfully.
+) else (
+    echo Chocolatey is already installed.
 )
 
-:: Install ADB and Scrcpy
+echo Installing ADB...
 choco install adb -y
-choco install scrcpy -y
+if %ERRORLEVEL% neq 0 (
+    echo Error: Failed to install ADB using Chocolatey.
+    pause
+    exit /b %ERRORLEVEL%
+)
+echo ADB installed successfully via Chocolatey.
 
-echo Setup complete! All dependencies are installed.
+echo Installing scrcpy...
+choco install scrcpy -y
+if %ERRORLEVEL% neq 0 (
+    echo Error: Failed to install scrcpy using Chocolatey.
+    pause
+    exit /b %ERRORLEVEL%
+)
+echo scrcpy installed successfully via Chocolatey.
+
+echo Setup complete! All specified dependencies are installed or were already present.
+pause


### PR DESCRIPTION
This commit introduces several improvements to enhance error handling, portability, and clarity of the project:

- `PHONECONTROL.BAT`:
    - Now runs relative to its own directory.
    - Explicitly calls `adb.exe` and `scrcpy.exe` from the bundled `Software/` directory using relative paths.
    - Includes error checking after `adb` and `scrcpy` commands, providing you feedback on failure.
    - Removed hardcoded absolute paths.

- `setup.bat`:
    - Added error checking after Chocolatey installation command.
    - Added `%ERRORLEVEL%` checks and notifications for you for `adb` and `scrcpy` installations via Chocolatey.
    - Ensures the final success message is accurate based on installation outcomes.

- `README.md`:
    - Removed hardcoded paths in usage instructions.
    - Clarified that `PHONECONTROL.BAT` uses bundled software from the `Software/` directory.
    - Added explanation for the purpose and usage of `setup.bat`.

- `scrcpy_instructions.txt`:
    - Updated to serve as a quick start guide, removing outdated information and hardcoded paths.
    - Aligned instructions with the current behavior of `PHONECONTROL.BAT` and `README.md`.

These changes make the project more robust, easier for you to use, and less prone to errors caused by path issues or failed dependency installations.